### PR TITLE
Turn on RTTI because Ubuntu LLVM builds have it enabled.

### DIFF
--- a/core/iwasm/compilation/iwasm_compl.cmake
+++ b/core/iwasm/compilation/iwasm_compl.cmake
@@ -16,11 +16,3 @@ endif()
 
 set (IWASM_COMPL_SOURCE ${source_all})
 
-# Disalbe rtti to works with LLVM
-
-if (MSVC)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
-else()
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-endif()
-


### PR DESCRIPTION
Ubuntu LLVM builds come with RTTI enabled, and mixed rtti flags cause linker errors. CPPrestsdk uses rtti internally which causes linker problems with Asio.